### PR TITLE
feat: add sections to form builder

### DIFF
--- a/Client/Components/LivePreview.razor
+++ b/Client/Components/LivePreview.razor
@@ -105,6 +105,17 @@
                 </table>
                 break;
 
+            case "image":
+                @if (!string.IsNullOrWhiteSpace(field.OptionsJson))
+                {
+                    var img = JsonSerializer.Deserialize<ImageOptions>(field.OptionsJson!);
+                    if (!string.IsNullOrEmpty(img?.Url))
+                    {
+                        <img src="@img.Url" style=@($"max-width:100%;width:{img.Width}px;") />
+                    }
+                }
+                break;
+
             case "file":
                 <input type="file" class="form-control" disabled />
                 break;
@@ -135,4 +146,5 @@
 @code {
     [Parameter] public List<DesignerRow> Rows { get; set; } = new();
     [Parameter] public string? FormName { get; set; }
+    private record ImageOptions(string Url, int Width);
 }

--- a/Client/Components/LivePreview.razor
+++ b/Client/Components/LivePreview.razor
@@ -1,4 +1,5 @@
 ﻿@using DynamicFormsApp.Shared
+@using System.Text.Json
 
 <h5 class="text-muted">Live Preview</h5>
 @if (!string.IsNullOrWhiteSpace(FormName))
@@ -115,6 +116,10 @@
             case "section":
                 <hr />
                 <h5>@field.Label</h5>
+                @if (!string.IsNullOrWhiteSpace(field.OptionsJson))
+                {
+                    <div class="text-muted">@(JsonSerializer.Deserialize<string>(field.OptionsJson!) ?? string.Empty)</div>
+                }
                 break;
 
             default:

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -110,16 +110,37 @@
                                             <option value="grid_checkbox">Checkbox Grid</option>
                                             <option value="title">Title and Description</option>
                                             <option value="file">Upload File</option>
+                                            <option value="image">Image</option>
                                         </select>
                                     </div>
-                                    <div class="col-md-4">
-                                        <input type="text" class="form-control"
-                                               placeholder="Option1, Option2, ..."
-                                               @bind="field.Options" />
-                                    </div>
+                                    @if (field.FieldType == "image")
+                                    {
+                                        <div class="col-md-4">
+                                            <input type="text" class="form-control" placeholder="Image URL" @bind="field.ImageUrl" />
+                                        </div>
+                                        <div class="col-md-4">
+                                            <label class="form-label mb-0">Width (@field.ImageWidth px)</label>
+                                            <input type="range" class="form-range" min="50" max="800" @bind="field.ImageWidth" />
+                                        </div>
+                                    }
+                                    else
+                                    {
+                                        <div class="col-md-4">
+                                            <input type="text" class="form-control"
+                                                   placeholder="Option1, Option2, ..."
+                                                   @bind="field.Options" />
+                                        </div>
+                                    }
                                 </div>
 
-                                @if (field.FieldType != "title")
+                                @if (field.FieldType == "image" && !string.IsNullOrWhiteSpace(field.ImageUrl))
+                                {
+                                    <div class="mt-2">
+                                        <img src="@field.ImageUrl" style=@($"max-width:100%;width:{field.ImageWidth}px;") />
+                                    </div>
+                                }
+
+                                @if (field.FieldType != "title" && field.FieldType != "image")
                                 {
                                     <div class="form-check mt-2">
                                         <input class="form-check-input" type="checkbox" @bind="field.IsRequired" />
@@ -177,6 +198,8 @@
         public string Label { get; set; } = string.Empty;
         public string FieldType { get; set; } = "text";
         public string Options { get; set; } = "";
+        public string ImageUrl { get; set; } = string.Empty;
+        public int ImageWidth { get; set; } = 200;
         public bool IsRequired { get; set; }
     }
 
@@ -252,6 +275,8 @@
             Label = src.Label,
             FieldType = src.FieldType,
             Options = src.Options,
+            ImageUrl = src.ImageUrl,
+            ImageWidth = src.ImageWidth,
             IsRequired = src.IsRequired
         };
         sections[sectionIndex].Fields.Insert(index + 1, copy);
@@ -311,13 +336,13 @@
 
             foreach (var f in section.Fields)
             {
-                if (string.IsNullOrWhiteSpace(f.Label))
+                if (f.FieldType != "image" && string.IsNullOrWhiteSpace(f.Label))
                 {
                     NotificationService.Notify(new NotificationMessage
                     {
                         Severity = NotificationSeverity.Warning,
                         Summary = "Field details missing",
-                        Detail = "Each field needs a label."
+                        Detail = "Each field needs a label.",
                     });
                     return;
                 }
@@ -329,7 +354,18 @@
                     {
                         Severity = NotificationSeverity.Warning,
                         Summary = "Options required",
-                        Detail = $"Add at least one option for '{f.Label}'."
+                        Detail = $"Add at least one option for '{f.Label}'.",
+                    });
+                    return;
+                }
+
+                if (f.FieldType == "image" && string.IsNullOrWhiteSpace(f.ImageUrl))
+                {
+                    NotificationService.Notify(new NotificationMessage
+                    {
+                        Severity = NotificationSeverity.Warning,
+                        Summary = "Image URL required",
+                        Detail = $"Please provide an image URL for '{f.Label}'.",
                     });
                     return;
                 }
@@ -353,10 +389,15 @@
                     Label = f.Label,
                     FieldType = f.FieldType,
                     IsRequired = f.IsRequired,
-                    OptionsJson = string.IsNullOrWhiteSpace(f.Options)
-                        ? null
-                        : JsonSerializer.Serialize(
-                            f.Options.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                    OptionsJson = f.FieldType switch
+                    {
+                        "radio" or "checkbox" or "dropdown" => string.IsNullOrWhiteSpace(f.Options)
+                            ? null
+                            : JsonSerializer.Serialize(
+                                f.Options.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)),
+                        "image" => JsonSerializer.Serialize(new { Url = f.ImageUrl, Width = f.ImageWidth }),
+                        _ => null
+                    }
                 });
             }
         }

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -1,4 +1,4 @@
-﻿@page "/razer"
+@page "/razer"
 @using System.Net.Http.Json
 @using System.Text.Json
 @using DynamicFormsApp.Shared.Models
@@ -8,8 +8,9 @@
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
 @inject IJSRuntime JS
+@inject NotificationService NotificationService
+@using Radzen
 @implements IDisposable
-@inject IJSRuntime JS
 
 <h2 class="mb-4">Form Builder</h2>
 
@@ -41,73 +42,108 @@
     </div>
 }
 
-<div id="simple-fields">
-@for (int index = 0; index < fields.Count; index++)
-{
-    var field = fields[index];
-    <div class="card mb-3 shadow-sm border-start border-5 border-primary" data-idx="@index">
-        <div class="card-body">
-            <div class="d-flex justify-content-between align-items-center mb-2">
+<div id="sections-container">
+    @for (int s = 0; s < sections.Count; s++)
+    {
+        var section = sections[s];
+        <div class="card mb-4" data-idx="@s">
+            <div class="card-header d-flex justify-content-between align-items-center">
                 <div class="d-flex align-items-center gap-2">
-                    <button type="button" class="btn btn-sm btn-outline-secondary move-handle">
+                    <button type="button" class="btn btn-sm btn-outline-secondary section-move-handle">
                         <span class="material-icons">drag_indicator</span>
                     </button>
-                    <input type="text"
-                           class="form-control form-control-sm"
-                           placeholder="Question/Label"
-                           @bind="field.Label" />
+                    <input type="text" class="form-control form-control-sm" placeholder="Section title" @bind="section.Title" />
                 </div>
                 <div class="btn-group">
-                    <button class="btn btn-sm btn-outline-secondary" @onclick="() => DuplicateField(index)">
-                        <span class="material-icons">content_copy</span>
+                    <button class="btn btn-sm btn-outline-secondary" @onclick="() => ToggleSection(s)">
+                        <span class="material-icons">@(!section.IsCollapsed ? "expand_less" : "expand_more")</span>
                     </button>
-                    <button class="btn btn-sm btn-outline-danger" @onclick="() => RemoveField(field)">
+                    <button class="btn btn-sm btn-outline-danger" @onclick="() => RemoveSection(s)">
                         <span class="material-icons">delete</span>
                     </button>
                 </div>
             </div>
-
-            <div class="row g-2 align-items-center">
-                <div class="col-md-4">
-                    <select class="form-select" @bind="field.FieldType">
-                        <option value="text">Short Answer</option>
-                        <option value="textarea">Paragraph</option>
-                        <option value="radio">Multiple Choice</option>
-                        <option value="checkbox">Checkbox</option>
-                        <option value="dropdown">Dropdown</option>
-                        <option value="date">Date</option>
-                        <option value="time">Time</option>
-                        <option value="datetime">Date Time</option>
-                        <option value="scale">Linear Scale</option>
-                        <option value="grid_radio">Multiple Choice Grid</option>
-                        <option value="grid_checkbox">Checkbox Grid</option>
-                        <option value="title">Title and Description</option>
-                        <option value="section">Section</option>
-                        <option value="file">Upload File</option>
-                    </select>
+            <div class="card-body @(section.IsCollapsed ? "d-none" : "")">
+                <div class="mb-3">
+                    <textarea class="form-control" placeholder="Section instructions" @bind="section.Instructions"></textarea>
                 </div>
-                <div class="col-md-4">
-                    <input type="text" class="form-control"
-                           placeholder="Option1, Option2, ..."
-                           @bind="field.Options" />
+
+                <div id="fields-list-@s">
+                    @for (int index = 0; index < section.Fields.Count; index++)
+                    {
+                        var field = section.Fields[index];
+                        <div class="card mb-3 shadow-sm border-start border-5 border-primary" data-idx="@index">
+                            <div class="card-body">
+                                <div class="d-flex justify-content-between align-items-center mb-2">
+                                    <div class="d-flex align-items-center gap-2">
+                                        <button type="button" class="btn btn-sm btn-outline-secondary move-handle">
+                                            <span class="material-icons">drag_indicator</span>
+                                        </button>
+                                        <input type="text"
+                                               class="form-control form-control-sm"
+                                               placeholder="Question/Label"
+                                               @bind="field.Label" />
+                                    </div>
+                                    <div class="btn-group">
+                                        <button class="btn btn-sm btn-outline-secondary" @onclick="() => DuplicateField(s, index)">
+                                            <span class="material-icons">content_copy</span>
+                                        </button>
+                                        <button class="btn btn-sm btn-outline-danger" @onclick="() => RemoveField(s, field)">
+                                            <span class="material-icons">delete</span>
+                                        </button>
+                                    </div>
+                                </div>
+
+                                <div class="row g-2 align-items-center">
+                                    <div class="col-md-4">
+                                        <select class="form-select" @bind="field.FieldType">
+                                            <option value="text">Short Answer</option>
+                                            <option value="textarea">Paragraph</option>
+                                            <option value="radio">Multiple Choice</option>
+                                            <option value="checkbox">Checkbox</option>
+                                            <option value="dropdown">Dropdown</option>
+                                            <option value="date">Date</option>
+                                            <option value="time">Time</option>
+                                            <option value="datetime">Date Time</option>
+                                            <option value="scale">Linear Scale</option>
+                                            <option value="grid_radio">Multiple Choice Grid</option>
+                                            <option value="grid_checkbox">Checkbox Grid</option>
+                                            <option value="title">Title and Description</option>
+                                            <option value="file">Upload File</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <input type="text" class="form-control"
+                                               placeholder="Option1, Option2, ..."
+                                               @bind="field.Options" />
+                                    </div>
+                                </div>
+
+                                @if (field.FieldType != "title")
+                                {
+                                    <div class="form-check mt-2">
+                                        <input class="form-check-input" type="checkbox" @bind="field.IsRequired" />
+                                        <label class="form-check-label">Required</label>
+                                    </div>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+
+                <div class="d-grid">
+                    <button class="btn btn-outline-secondary" @onclick="() => AddField(s)">
+                        + Add Field
+                    </button>
                 </div>
             </div>
-
-            @if (field.FieldType != "title" && field.FieldType != "section")
-            {
-                <div class="form-check mt-2">
-                    <input class="form-check-input" type="checkbox" @bind="field.IsRequired" />
-                    <label class="form-check-label">Required</label>
-                </div>
-            }
         </div>
-    </div>
-}
+    }
 </div>
 
 <div class="d-grid mb-3">
-    <button class="btn btn-outline-secondary" @onclick="AddField">
-        + Add New Field
+    <button class="btn btn-outline-secondary" @onclick="AddSection">
+        + Add New Section
     </button>
 </div>
 
@@ -120,12 +156,29 @@
 @code {
     private string formName = string.Empty;
     private string formDescription = string.Empty;
-    private List<DesignerField> fields = new();
+    private List<FormSection> sections = new() { new FormSection() };
     private bool requireLogin = true;
     private bool notifyOnResponse = false;
     private string notificationEmail = string.Empty;
     private UserModel? currentUser;
     private DotNetObjectReference<FormDesigner>? objRef;
+
+    class FormSection
+    {
+        public string Title { get; set; } = string.Empty;
+        public string Instructions { get; set; } = string.Empty;
+        public bool IsCollapsed { get; set; }
+        public List<DesignerField> Fields { get; set; } = new();
+    }
+
+    class DesignerField
+    {
+        public string Key { get; set; } = string.Empty;
+        public string Label { get; set; } = string.Empty;
+        public string FieldType { get; set; } = "text";
+        public string Options { get; set; } = "";
+        public bool IsRequired { get; set; }
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -144,34 +197,55 @@
             }
 
             objRef = DotNetObjectReference.Create(this);
-            await JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef);
+            await InitSortables();
         }
     }
 
-    class DesignerField
+    async Task InitSortables()
     {
-        public string Key { get; set; } = string.Empty;
-        public string Label { get; set; } = string.Empty;
-        public string FieldType { get; set; } = "text";
-        public string Options { get; set; } = "";
-        public bool IsRequired { get; set; }
+        await JS.InvokeVoidAsync("initSectionSortable", "#sections-container", objRef!);
+        for (int i = 0; i < sections.Count; i++)
+        {
+            await JS.InvokeVoidAsync("initFieldSortable", $"#fields-list-{i}", i, objRef!);
+        }
     }
 
-    void AddField()
+    void AddSection()
     {
-        fields.Add(new DesignerField());
-        JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
+        sections.Add(new FormSection());
+        _ = InitSortables();
     }
 
-    void RemoveField(DesignerField field)
+    async Task RemoveSection(int index)
     {
-        fields.Remove(field);
-        JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
+        if (await JS.InvokeAsync<bool>("confirm", "Delete this section?"))
+        {
+            sections.RemoveAt(index);
+            await InitSortables();
+            StateHasChanged();
+        }
     }
 
-    void DuplicateField(int index)
+    void ToggleSection(int index)
     {
-        var src = fields[index];
+        sections[index].IsCollapsed = !sections[index].IsCollapsed;
+    }
+
+    void AddField(int sectionIndex)
+    {
+        sections[sectionIndex].Fields.Add(new DesignerField());
+        _ = InitSortables();
+    }
+
+    void RemoveField(int sectionIndex, DesignerField field)
+    {
+        sections[sectionIndex].Fields.Remove(field);
+        _ = InitSortables();
+    }
+
+    void DuplicateField(int sectionIndex, int index)
+    {
+        var src = sections[sectionIndex].Fields[index];
         var copy = new DesignerField
         {
             Key = string.Empty,
@@ -180,18 +254,32 @@
             Options = src.Options,
             IsRequired = src.IsRequired
         };
-        fields.Insert(index + 1, copy);
-        JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
+        sections[sectionIndex].Fields.Insert(index + 1, copy);
+        _ = InitSortables();
     }
 
     [JSInvokable]
-    public void OnFieldReorder(int oldIndex, int newIndex)
+    public void OnSectionReorder(int oldIndex, int newIndex)
     {
-        if (oldIndex == newIndex || oldIndex < 0 || newIndex < 0 || oldIndex >= fields.Count || newIndex >= fields.Count)
-            return;
-        var item = fields[oldIndex];
-        fields.RemoveAt(oldIndex);
-        fields.Insert(newIndex, item);
+        if (oldIndex == newIndex || oldIndex < 0 || newIndex < 0 ||
+            oldIndex >= sections.Count || newIndex >= sections.Count) return;
+        var item = sections[oldIndex];
+        sections.RemoveAt(oldIndex);
+        sections.Insert(newIndex, item);
+        _ = InitSortables();
+        StateHasChanged();
+    }
+
+    [JSInvokable]
+    public void OnFieldReorder(int sectionIndex, int oldIndex, int newIndex)
+    {
+        if (sectionIndex < 0 || sectionIndex >= sections.Count) return;
+        var list = sections[sectionIndex].Fields;
+        if (oldIndex == newIndex || oldIndex < 0 || newIndex < 0 ||
+            oldIndex >= list.Count || newIndex >= list.Count) return;
+        var item = list[oldIndex];
+        list.RemoveAt(oldIndex);
+        list.Insert(newIndex, item);
         StateHasChanged();
     }
 
@@ -208,29 +296,68 @@
             return;
         }
 
-        foreach (var f in fields)
+        foreach (var section in sections)
         {
-            if (string.IsNullOrWhiteSpace(f.Label))
+            if (string.IsNullOrWhiteSpace(section.Title))
             {
                 NotificationService.Notify(new NotificationMessage
                 {
                     Severity = NotificationSeverity.Warning,
-                    Summary = "Field details missing",
-                    Detail = "Each field needs a label."
+                    Summary = "Section title missing",
+                    Detail = "Each section needs a title."
                 });
                 return;
             }
 
-            if ((f.FieldType == "radio" || f.FieldType == "checkbox" || f.FieldType == "dropdown") &&
-                f.Options.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Length == 0)
+            foreach (var f in section.Fields)
             {
-                NotificationService.Notify(new NotificationMessage
+                if (string.IsNullOrWhiteSpace(f.Label))
                 {
-                    Severity = NotificationSeverity.Warning,
-                    Summary = "Options required",
-                    Detail = $"Add at least one option for '{f.Label}'."
+                    NotificationService.Notify(new NotificationMessage
+                    {
+                        Severity = NotificationSeverity.Warning,
+                        Summary = "Field details missing",
+                        Detail = "Each field needs a label."
+                    });
+                    return;
+                }
+
+                if ((f.FieldType == "radio" || f.FieldType == "checkbox" || f.FieldType == "dropdown") &&
+                    f.Options.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Length == 0)
+                {
+                    NotificationService.Notify(new NotificationMessage
+                    {
+                        Severity = NotificationSeverity.Warning,
+                        Summary = "Options required",
+                        Detail = $"Add at least one option for '{f.Label}'."
+                    });
+                    return;
+                }
+            }
+        }
+
+        var flattened = new List<object>();
+        foreach (var section in sections)
+        {
+            flattened.Add(new
+            {
+                Label = section.Title,
+                FieldType = "section",
+                IsRequired = false,
+                OptionsJson = string.IsNullOrWhiteSpace(section.Instructions) ? null : JsonSerializer.Serialize(section.Instructions)
+            });
+            foreach (var f in section.Fields)
+            {
+                flattened.Add(new
+                {
+                    Label = f.Label,
+                    FieldType = f.FieldType,
+                    IsRequired = f.IsRequired,
+                    OptionsJson = string.IsNullOrWhiteSpace(f.Options)
+                        ? null
+                        : JsonSerializer.Serialize(
+                            f.Options.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
                 });
-                return;
             }
         }
 
@@ -242,17 +369,7 @@
             NotifyOnResponse = notifyOnResponse,
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
             IsActive = true,
-            Fields = fields.Select(f => new
-            {
-                Label = f.Label,
-                FieldType = f.FieldType,
-                IsRequired = f.IsRequired,
-                OptionsJson = string.IsNullOrWhiteSpace(f.Options)
-                    ? null
-                    : JsonSerializer.Serialize(
-                        f.Options.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                    )
-            }).ToList()
+            Fields = flattened
         };
 
         var resp = await Http.PostAsJsonAsync("api/forms", payload);

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -123,6 +123,17 @@ else
                         }
                         break;
 
+                    case "image":
+                        if (!string.IsNullOrWhiteSpace(fld.OptionsJson))
+                        {
+                            var img = JsonSerializer.Deserialize<ImageOptions>(fld.OptionsJson!);
+                            if (!string.IsNullOrEmpty(img?.Url))
+                            {
+                                <img src="@img.Url" style=@($"max-width:100%;width:{img.Width}px;") />
+                            }
+                        }
+                        break;
+
                     case "file":
                         <InputFile OnChange="e => OnFileUploadChanged(fld.Key, e)" />
                         @if (responseData.ContainsKey(fld.Key))
@@ -358,4 +369,6 @@ else
     {
         public string filePath { get; set; }
     }
+
+    private record ImageOptions(string Url, int Width);
 }

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -138,6 +138,10 @@ else
                     case "section":
                         <hr />
                         <h5>@fld.Label</h5>
+                        @if (!string.IsNullOrWhiteSpace(fld.OptionsJson))
+                        {
+                            <div class="text-muted">@(JsonSerializer.Deserialize<string>(fld.OptionsJson!) ?? string.Empty)</div>
+                        }
                         break;
 
                     case "scale":

--- a/NdaProcesses.Shared/DesignerField.cs
+++ b/NdaProcesses.Shared/DesignerField.cs
@@ -10,6 +10,9 @@
         // Dynamic options
         public List<string> OptionItems { get; set; } = new();
 
+        // Serialized options or additional metadata
+        public string? OptionsJson { get; set; }
+
         // Grid layout (for grid types)
         public List<string> GridRows { get; set; } = new();
         public List<string> GridColumns { get; set; } = new();

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -56,34 +56,113 @@ namespace DynamicFormsApp.Server.Services
                 .Where(f => !dto.Fields.Any(n => string.Equals(n.Key, f.Key, StringComparison.OrdinalIgnoreCase)))
                 .ToList();
 
-            if (deletions.Count > 0)
+            if (deletions.Count > 0 && !existing.IsDraft)
             {
-                if (!existing.IsDraft)
+                // Archive the current form under a new ID
+                var archived = new Form
                 {
-                    // Deleting fields requires a new version with a fresh table
-                    existing.IsActive = false;
-                    await _db.SaveChangesAsync();
-
-                    var newId = await CreateFormAsync(dto.Name, dto.Description, dto.Fields, user,
-                        dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive,
-                        dto.IsDraft, existing.Version + 1, existing.Id);
-
-                    return newId;
-                }
-                else
-                {
-                    var rawName = SanitizeKey(existing.Name);
-                    var tableName = $"Form_{existing.Id}_{rawName}";
-                    foreach (var del in deletions)
+                    Name = existing.Name,
+                    Description = existing.Description,
+                    CreatedBy = existing.CreatedBy,
+                    RequireLogin = existing.RequireLogin,
+                    NotifyOnResponse = existing.NotifyOnResponse,
+                    NotificationEmail = existing.NotificationEmail,
+                    IsActive = false,
+                    IsDeleted = existing.IsDeleted,
+                    IsDraft = false,
+                    Version = existing.Version,
+                    PreviousVersionId = existing.PreviousVersionId,
+                    Fields = existing.Fields.Select(f => new FormField
                     {
-                        var sql = $"ALTER TABLE [{tableName}] DROP COLUMN [{del.Key}];";
-                        await _db.Database.ExecuteSqlRawAsync(sql);
-                        _db.FormFields.Remove(del);
-                    }
+                        Key = f.Key,
+                        Label = f.Label,
+                        FieldType = f.FieldType,
+                        IsRequired = f.IsRequired,
+                        OptionsJson = f.OptionsJson,
+                        Row = f.Row,
+                        Column = f.Column
+                    }).ToList()
+                };
+
+                _db.Forms.Add(archived);
+                await _db.SaveChangesAsync();
+
+                // Rename the response table to use the archived form ID
+                var oldRaw = SanitizeKey(existing.Name);
+                var oldTable = $"Form_{existing.Id}_{oldRaw}";
+                var archivedTable = $"Form_{archived.Id}_{oldRaw}";
+                await _db.Database.ExecuteSqlRawAsync($"EXEC sp_rename '{oldTable}', '{archivedTable}'");
+
+                // Remove old field records from the active form
+                _db.FormFields.RemoveRange(existing.Fields);
+                await _db.SaveChangesAsync();
+
+                existing.Fields = new List<FormField>();
+                existing.Version = archived.Version + 1;
+                existing.PreviousVersionId = archived.Id;
+
+                // Recreate the form fields from the DTO
+                var keySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var fld in dto.Fields)
+                {
+                    var keySource = string.IsNullOrWhiteSpace(fld.Key) ? fld.Label : fld.Key;
+                    existing.Fields.Add(new FormField
+                    {
+                        Key = GetUniqueKey(keySource, keySet),
+                        Label = fld.Label,
+                        FieldType = fld.FieldType,
+                        IsRequired = fld.IsRequired,
+                        OptionsJson = fld.OptionsJson,
+                        Row = fld.Row,
+                        Column = fld.Column
+                    });
+                }
+
+                // Update metadata on the existing record
+                existing.Name = dto.Name;
+                existing.Description = dto.Description;
+                existing.RequireLogin = dto.RequireLogin;
+                existing.NotifyOnResponse = dto.NotifyOnResponse;
+                existing.NotificationEmail = dto.NotificationEmail;
+                existing.IsActive = dto.IsActive;
+                existing.IsDraft = dto.IsDraft;
+
+                await _db.SaveChangesAsync();
+
+                // Create a fresh response table for the updated form ID
+                var rawName = SanitizeKey(existing.Name);
+                var tableName = $"Form_{existing.Id}_{rawName}";
+                var sb = new StringBuilder(
+                    $"CREATE TABLE [{tableName}] (" +
+                    "ResponseId INT IDENTITY(1,1) PRIMARY KEY, " +
+                    "CreatedAt DATETIME2 NOT NULL");
+                if (dto.RequireLogin)
+                {
+                    sb.Append(", [ResponderName] NVARCHAR(255) NULL");
+                }
+                foreach (var fld in existing.Fields)
+                {
+                    sb.Append($", [{fld.Key}] {MapToSqlType(fld.FieldType)} {(fld.IsRequired ? "NOT NULL" : "NULL")}");
+                }
+                sb.Append(");");
+                await _db.Database.ExecuteSqlRawAsync(sb.ToString());
+
+                return existing.Id;
+            }
+            else if (deletions.Count > 0)
+            {
+                // Draft forms can drop columns in place
+                var rawName = SanitizeKey(existing.Name);
+                var tableName = $"Form_{existing.Id}_{rawName}";
+                foreach (var del in deletions)
+                {
+                    var sql = $"ALTER TABLE [{tableName}] DROP COLUMN [{del.Key}];";
+                    await _db.Database.ExecuteSqlRawAsync(sql);
+                    _db.FormFields.Remove(del);
                 }
             }
 
-            // Update in place when no fields are removed
+            // Update in place when no archival is needed
             existing.Name = dto.Name;
             existing.Description = dto.Description;
             existing.RequireLogin = dto.RequireLogin;
@@ -92,7 +171,7 @@ namespace DynamicFormsApp.Server.Services
             existing.IsActive = dto.IsActive;
             existing.IsDraft = dto.IsDraft;
 
-            var keySet = new HashSet<string>(existing.Fields.Select(f => f.Key), StringComparer.OrdinalIgnoreCase);
+            var keySetUpdate = new HashSet<string>(existing.Fields.Select(f => f.Key), StringComparer.OrdinalIgnoreCase);
 
             foreach (var fld in dto.Fields)
             {
@@ -109,7 +188,7 @@ namespace DynamicFormsApp.Server.Services
                 else
                 {
                     var keySource = string.IsNullOrWhiteSpace(fld.Key) ? fld.Label : fld.Key;
-                    var key = GetUniqueKey(keySource, keySet);
+                    var key = GetUniqueKey(keySource, keySetUpdate);
                     var newField = new FormField
                     {
                         Key = key,

--- a/Server/wwwroot/js/sortable-wrapper.js
+++ b/Server/wwwroot/js/sortable-wrapper.js
@@ -25,13 +25,40 @@ window.initSortable = (selector, dotnetHelper) => {
     });
 };
 
-window.initListSortable = (selector, dotnetHelper) => {
+// simple list sortable used by original designer
+window.initListSortable = (selector, dotnetHelper, callback) => {
     const container = document.querySelector(selector);
     if (!container || container.dataset.sortableInit === 'true') return;
     container.dataset.sortableInit = 'true';
     new Sortable(container, {
         animation: 150,
         handle: '.move-handle',
-        onEnd: evt => dotnetHelper.invokeMethodAsync('OnFieldReorder', evt.oldIndex, evt.newIndex)
+        onEnd: evt => dotnetHelper.invokeMethodAsync(callback || 'OnFieldReorder', evt.oldIndex, evt.newIndex)
+    });
+};
+
+// sortable for sections in the form designer
+window.initSectionSortable = (selector, dotnetHelper) => {
+    const container = document.querySelector(selector);
+    if (!container) return;
+    if (container.dataset.sortableInit === 'true') return;
+    container.dataset.sortableInit = 'true';
+    new Sortable(container, {
+        animation: 150,
+        handle: '.section-move-handle',
+        onEnd: evt => dotnetHelper.invokeMethodAsync('OnSectionReorder', evt.oldIndex, evt.newIndex)
+    });
+};
+
+// sortable for fields inside a specific section
+window.initFieldSortable = (selector, sectionIndex, dotnetHelper) => {
+    const container = document.querySelector(selector);
+    if (!container) return;
+    if (container.dataset.sortableInit === 'true') return;
+    container.dataset.sortableInit = 'true';
+    new Sortable(container, {
+        animation: 150,
+        handle: '.move-handle',
+        onEnd: evt => dotnetHelper.invokeMethodAsync('OnFieldReorder', sectionIndex, evt.oldIndex, evt.newIndex)
     });
 };


### PR DESCRIPTION
## Summary
- add dedicated sections to the form designer with collapsible headers, instructions, and field grouping
- support drag-and-drop reordering for both sections and fields via new JS helpers
- render section instructions in previews and on completed forms
- preserve form IDs when archiving deleted-field versions so existing IDs stay stable

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689239d9d0048329859e056dd6903c45